### PR TITLE
Refactoring

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -3,4 +3,3 @@ val r = scala.util.Random
 
 @main def main(args: String*) =
   val config = Parser(args)
-  print(config)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -3,3 +3,4 @@ val r = scala.util.Random
 
 @main def main(args: String*) =
   val config = Parser(args)
+  print(config)

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -3,6 +3,7 @@ import scopt.Read
 import java.text.SimpleDateFormat
 import java.util.Date
 import scala.util.matching.Regex
+import scala.compiletime.ops.string
 
 // Recursive funtion for processing tasks
 object Parser {
@@ -10,8 +11,9 @@ object Parser {
   def apply(args: Seq[String]) =
     OParser.parse(parser, args, Config()) match
       // This is where our task object will end up as part of the config object
-      case Some(config) => config
-      case _            => None
+      case Some(config) => println(config)
+      case _            => println("PLEASE ENTER ARGS: pg task --add name=hello,description=world,effort=12,due=2020-02-12"
+                                   )
 
   def parseTask(
       params: Map[String, Any] = Map(),
@@ -63,30 +65,13 @@ implicit val taskRead: Read[Task] = Read.reads { (s: String) =>
       s.split(s",").toList.map(_.split("=").toList).flatten
     )
   // TODO Find a more scalable way to do argument validation, move this into scopt validation as well.
-  if (args.size == 1)
-    println(
-      "Entered wrong arguments" + "Please Enter args: pg add name=hello,description=world,effort=12,due=2020-02-12"
-    )
-  else
-    // TODO This is bad scala practice, we shouldn't cause unnessary side effects.
-    println("")
+  
   Task(
     args("name").asInstanceOf[String],
     args("description").asInstanceOf[String],
     args("effort").asInstanceOf[Int],
     args("due").asInstanceOf[Date]
   )
-}
-
-// TODO Please move this as a validation stage within scopt
-def validArg(s: String): Boolean = {
-  val pattern = new Regex(
-    "^pg task --add name=[a-zA-z]+,description=[a-zA-Z\\s]+,effort=[0-9],due=(\\d{4})-([01][0-9])-([012][0-9])$"
-  )
-  if (pattern.findAllIn(s).toList.length == 1)
-    return true
-  else
-    return false
 }
 
 case class Config(

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -11,9 +11,8 @@ object Parser {
   def apply(args: Seq[String]) =
     OParser.parse(parser, args, Config()) match
       // This is where our task object will end up as part of the config object
-      case Some(config) => println(config)
-      case _            => println("PLEASE ENTER ARGS: pg task --add name=hello,description=world,effort=12,due=2020-02-12"
-                                   )
+      case Some(config) => config
+      case _            => None
 
   def parseTask(
       params: Map[String, Any] = Map(),
@@ -51,7 +50,9 @@ object Parser {
           opt[Task]("add")
             .required()
             .action((x, c) => c.copy(task = Some(x)))
+            .text("Example: pg task --add name=hello,description=world,effort=12,due=2020-02-12")   
         )
+        
     )
 
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -2,8 +2,8 @@ import scopt.OParser
 import scopt.Read
 import java.text.SimpleDateFormat
 import java.util.Date
-import scala.util.matching.Regex
-import scala.compiletime.ops.string
+
+
 
 // Recursive funtion for processing tasks
 object Parser {
@@ -65,8 +65,7 @@ implicit val taskRead: Read[Task] = Read.reads { (s: String) =>
     Parser.parseTask(args =
       s.split(s",").toList.map(_.split("=").toList).flatten
     )
-  // TODO Find a more scalable way to do argument validation, move this into scopt validation as well.
-  
+
   Task(
     args("name").asInstanceOf[String],
     args("description").asInstanceOf[String],

--- a/src/test/scala/Tests.scala
+++ b/src/test/scala/Tests.scala
@@ -16,11 +16,11 @@ class PersonalGamificationSpec extends AnyFlatSpec with should.Matchers:
     val strSeq3:Seq[String]=Seq("task", "--add", "aaaaaadkajkdjkajdkajdkajkdjkajdka111")
     val strSeq4:Seq[String]=Seq("task", "--add",  "namehellodescriptionworldeffort122022-3-22")
 
-    Parser.apply(strSeq)
+    //Parser.apply(strSeq)
     //Parser.apply(strSeq1)
     //Parser.apply(strSeq2)
     //Parser.apply(strSeq3)
-    //Parser.apply(strSeq4)
+    Parser.apply(strSeq4)
   }
    
   // val playerFile = File("player.yaml")

--- a/src/test/scala/Tests.scala
+++ b/src/test/scala/Tests.scala
@@ -5,26 +5,22 @@ import matchers._
 import com.fasterxml.jackson.core.`type`.TypeReference
 
 
+
 class PersonalGamificationSpec extends AnyFlatSpec with should.Matchers:
 
-  it should "tell whether args are formatted correctly" in {
-    val args="pg task add name=hello,description=world,effort=1,due=2022-02-22"
-    assert(validArg(args)==true)
-    // val args1="pg add"
-    // assert(validArg(args1)==false)
-    // val args2="pg add 122313i3i1o313io13i"
-    // assert(validArg(args2)==false)
-    // val args3="pg add nami=hello, description=world, effort=12, due=2022-3-22"
-    // assert(validArg(args3)==false)
-    // val args4=  "pg add namehellodescriptionworldeffort122022-3-22"
-    // assert(validArg(args4)==false)
-    // val args5= "pg add nami=hello, description=world, effort=12, due=hello"
-    // assert(validArg(args5)==false)     
-  }
-  it should "take in args and read the taskfrom it" in {
-    val arg="pg task"
-    //Oparser.parse(taskRead, arg, config())    
-    main()
+  it should "take Properly format args and create a task object" in {
+    //val args="pg task add name=hello,description=world,effort=1,due=2022-02-22"
+    val strSeq: Seq[String]=Seq("task", "--add")
+    val strSeq1:Seq[String]=Seq("task", "--add", "name=hello, description=world, effort=12, due=2022-3-22")
+    val strSeq2:Seq[String]=Seq("task", "--add", "name=hello,description=world,effort=12,due=hello")
+    val strSeq3:Seq[String]=Seq("task", "--add", "aaaaaadkajkdjkajdkajdkajkdjkajdka111")
+    val strSeq4:Seq[String]=Seq("task", "--add",  "namehellodescriptionworldeffort122022-3-22")
+
+    Parser.apply(strSeq)
+    //Parser.apply(strSeq1)
+    //Parser.apply(strSeq2)
+    //Parser.apply(strSeq3)
+    //Parser.apply(strSeq4)
   }
    
   // val playerFile = File("player.yaml")
@@ -37,7 +33,6 @@ class PersonalGamificationSpec extends AnyFlatSpec with should.Matchers:
   //   playerFile.delete()
   //   hasBeenSaved should be(true)
   // }
-
   // it should "load a Player object" in {
   //   val player1 = Player()
   //   player1.save(playerFile)

--- a/src/test/scala/Tests.scala
+++ b/src/test/scala/Tests.scala
@@ -9,19 +9,22 @@ import com.fasterxml.jackson.core.`type`.TypeReference
 class PersonalGamificationSpec extends AnyFlatSpec with should.Matchers:
 
   it should "take Properly format args and create a task object" in {
-    //val args="pg task add name=hello,description=world,effort=1,due=2022-02-22"
+
     val strSeq: Seq[String]=Seq("task", "--add")
     val strSeq1:Seq[String]=Seq("task", "--add", "name=hello, description=world, effort=12, due=2022-3-22")
-    val strSeq2:Seq[String]=Seq("task", "--add", "name=hello,description=world,effort=12,due=hello")
+    val strSeq2:Seq[String]=Seq("task", "--add", "name=42.35,description=-1000,effort=12,due=2022-3-22")
     val strSeq3:Seq[String]=Seq("task", "--add", "aaaaaadkajkdjkajdkajdkajkdjkajdka111")
     val strSeq4:Seq[String]=Seq("task", "--add",  "namehellodescriptionworldeffort122022-3-22")
 
-    //Parser.apply(strSeq)
-    //Parser.apply(strSeq1)
-    //Parser.apply(strSeq2)
-    //Parser.apply(strSeq3)
-    Parser.apply(strSeq4)
+      Parser.apply(strSeq)
+      Parser.apply(strSeq1)
+      Parser.apply(strSeq2)
+      Parser.apply(strSeq3)
+      Parser.apply(strSeq4) 
+    
   }
+    
+
    
   // val playerFile = File("player.yaml")
   // val taskFile = File("tasks.yaml")


### PR DESCRIPTION
With the parser, I was able to test the behavior as a whole and I found that scopt read throws an error when the user puts input that is not formatted along the line of Example: pg task --add name=hello,description=world,effort=12,due=2020-02-12. If they did not enter anything for the task, value not for a number for effort, and if the date is not formated correctly too. For the run time exception because it checks for error and allow for the correct input. it does not cause runtime exception for asinsatnceof.